### PR TITLE
Update configuration for Candida albicans and glabrata analysis

### DIFF
--- a/config/species.yaml
+++ b/config/species.yaml
@@ -1,24 +1,19 @@
 species:
-  - code: afumigatus
-    name: Aspergillus fumigatus
-    genome_dir: data/genomes/afumigatus/
-    gaf: data/go/mappings/afumigatus.gaf
-    cug_clade: false
   - code: candida_albicans
     name: Candida albicans
     genome_dir: data/genomes/candida_albicans/
-    gaf: data/go/mappings/candida_albicans.gaf
+    gaf: data/gene_association.cgd
     cug_clade: true
-  - code: candida_tropicalis
-    name: Candida tropicalis
-    genome_dir: data/genomes/candida_tropicalis/
-    gaf: data/go/mappings/candida_tropicalis.gaf
-    cug_clade: true
-go_obo: data/go/go.obo
+  - code: candida_glabrata
+    name: Candida glabrata
+    genome_dir: data/genomes/candida_glabrata/
+    gaf: data/gene_association.cgd
+    cug_clade: false
+go_obo: data/go.obo
 adaptive:
   start_pct: 95
-  step_pct: 10
-  rounds: 3
+  step_pct: 5
+  rounds: 7
 wobble_only: true
 wobble_aas:
   - Leu

--- a/src/codon_go/utils/config_loader.py
+++ b/src/codon_go/utils/config_loader.py
@@ -159,8 +159,8 @@ def get_default_config() -> Dict[str, Any]:
         'go_obo': 'data/go/go.obo',
         'adaptive': {
             'start_pct': 95,
-            'step_pct': 10,
-            'rounds': 3
+            'step_pct': 5,
+            'rounds': 7
         },
         'wobble_only': False,
         'wobble_aas': ['Leu', 'Lys', 'Gln', 'Glu', 'Phe', 'Trp', 'Ser'],


### PR DESCRIPTION
- Configure both C. albicans (CUG-clade) and C. glabrata (non-CUG-clade)
- Use shared GAF file: data/gene_association.cgd for both species
- Set albicans as CUG-clade (true) and glabrata as non-CUG-clade (false)
- Increase analysis granularity: 7 rounds with 5% steps (95% to 65%)
- Remove other species (afumigatus, tropicalis) to focus on these two

New threshold sequence: 95%, 90%, 85%, 80%, 75%, 70%, 65% This provides much finer resolution for codon usage analysis.