### PR TITLE
Fix unpacking error and add logging to file

### DIFF
--- a/src/codon_go/analysis/stats.py
+++ b/src/codon_go/analysis/stats.py
@@ -124,9 +124,13 @@ def adaptive_go_analysis_by_codon(
                 result['amino_acid'] = aa
                 results.append(result)
     
+    # Always create diagnostic DataFrame (even if no results)
+    diagnostic_df = pd.DataFrame(diagnostic_data)
+    logger.info(f"Generated diagnostic data for {len(diagnostic_df)} codon/threshold combinations")
+    
     if not results:
         logger.warning("No results generated from adaptive codon analysis")
-        return pd.DataFrame()
+        return pd.DataFrame(), diagnostic_df
     
     # Convert to DataFrame and adjust p-values
     results_df = pd.DataFrame(results)
@@ -142,10 +146,6 @@ def adaptive_go_analysis_by_codon(
     results_df = results_df.sort_values(['codon', 'adj_p_value'])
     
     logger.info(f"Completed adaptive codon analysis: {len(results_df)} total tests across {len(unique_codons)} codons")
-    
-    # Create diagnostic DataFrame and return both
-    diagnostic_df = pd.DataFrame(diagnostic_data)
-    logger.info(f"Generated diagnostic data for {len(diagnostic_df)} codon/threshold combinations")
     
     return results_df, diagnostic_df
 

--- a/src/codon_go/parsers/genome_parser.py
+++ b/src/codon_go/parsers/genome_parser.py
@@ -153,6 +153,33 @@ def _extract_all_gene_ids(feature: SeqFeature) -> Dict[str, str]:
     return ids
 
 
+def create_gene_id_mapping(records: Dict[str, SeqRecord]) -> Dict[str, str]:
+    """
+    Create a mapping from genome gene IDs to GAF-compatible IDs.
+    
+    This function analyzes all gene IDs in the genome records and attempts
+    to create a mapping to GAF file compatible IDs.
+    
+    Args:
+        records: Dictionary of gene_id → SeqRecord from genome files
+        
+    Returns:
+        Dictionary mapping genome_gene_id → gaf_gene_id
+    """
+    logger.info("Creating gene ID mapping for GAF compatibility")
+    
+    # For now, return identity mapping - this can be enhanced based on
+    # the specific ID formats found in the files
+    mapping = {gene_id: gene_id for gene_id in records.keys()}
+    
+    # Log some examples for debugging
+    sample_ids = list(records.keys())[:5]
+    logger.info(f"Sample genome gene IDs: {sample_ids}")
+    logger.info(f"Gene ID mapping created for {len(mapping)} genes")
+    
+    return mapping
+
+
 def validate_cds_sequences(records: Dict[str, SeqRecord]) -> Dict[str, SeqRecord]:
     """
     Validate CDS sequences for proper length and start/stop codons.


### PR DESCRIPTION
- Fix 'not enough values to unpack' error by always returning diagnostic data
- Add comprehensive logging to file (codon_go_analysis.log) in addition to console
- Set up proper logging configuration with file and console handlers
- Reorganize main function to load config first for proper log file location
- Add gene ID mapping framework for handling EMBL vs GAF ID mismatches
- Enhanced genome parser to support CGD systematic names and database IDs

Fixes the critical unpacking error and ensures all diagnostic information is logged to file for analysis. Gene ID mismatch (C1_00030C_A vs CAL0000196141) is now clearly identified in logs.